### PR TITLE
Update versions in examples to minor

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   garmin-connect-activity-exporter:
     container_name: garmin-connect-activity-exporter
-    image: ghcr.io/nareddyt/garmin-connect-activity-exporter:v1
+    image: ghcr.io/nareddyt/garmin-connect-activity-exporter:v1.0
     restart: unless-stopped
     environment:
       # Set these sensitive values via a `.env` file.

--- a/examples/kubernetes.yaml
+++ b/examples/kubernetes.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: garmin-connect-activity-exporter
-        image: ghcr.io/nareddyt/garmin-connect-activity-exporter:v1
+        image: ghcr.io/nareddyt/garmin-connect-activity-exporter:v1.0
         imagePullPolicy: IfNotPresent
         env:
         - name: GARMIN_USERNAME


### PR DESCRIPTION
This pull request updates the Docker image tag used for the `garmin-connect-activity-exporter` service in both Docker Compose and Kubernetes example configuration files. The image tag is changed from a generic `v1` to a more specific `v1.0`, ensuring consistency and clarity about the exact version being deployed.

Versioning updates:

* [`examples/docker-compose.yaml`](diffhunk://#diff-34686806ce7369ba8aea6b65936d44d3fe45a2799ac680b4f12741adaa0eed2bL4-R4): Changed the `image` tag for `garmin-connect-activity-exporter` from `v1` to `v1.0`.
* [`examples/kubernetes.yaml`](diffhunk://#diff-fa94fbc7c6360cfa3802a75a763ff9d14832a14edf8c616d6a27debb6d0264b9L63-R63): Updated the container image tag for `garmin-connect-activity-exporter` from `v1` to `v1.0` in the Kubernetes deployment spec.